### PR TITLE
Update requests.go

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -78,6 +78,9 @@ func Requests() *Request {
 	jar, _ := cookiejar.New(nil)
 
 	req.Client.Jar = jar
+	req.httpreq.GetBody = func() (io.ReadCloser, error) {
+		return ioutil.NopCloser(req.httpreq.Body), nil
+	}
 
 	return req
 }


### PR DESCRIPTION
防止 http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error 错误